### PR TITLE
修复 2 处 TabBar 的显示问题

### DIFF
--- a/plugin/knowledge_base.py
+++ b/plugin/knowledge_base.py
@@ -24,6 +24,8 @@ class KnowledgeBaseDialog(QDialog):
         
         layout.addLayout(button_layout)
 
+        self.tab_widget.setStyleSheet("QTabBar::tab {min-width: 100px;}")
+
     def create_tabs(self):
         self.add_tab("基本功能", self.load_basic_knowledge())
         self.add_tab("高级功能", self.load_advanced_knowledge())

--- a/ui/config_dialog.py
+++ b/ui/config_dialog.py
@@ -66,6 +66,7 @@ class ConfigDialog(QDialog):
         
         # 创建选项卡
         tab_widget = QTabWidget()
+        tab_widget.setStyleSheet("QTabBar::tab {min-width: 100px;}")
         
         # 工具路径设置选项卡
         tools_tab = QWidget()


### PR DESCRIPTION
将`配置设置`和`常备知识`的 TabBar 最小长度修改为 100px
**修改前：**
![配置设置-修改前](https://github.com/user-attachments/assets/c06784e1-664e-4951-bfbe-b8f4ed65725f)
![常备知识-修改前](https://github.com/user-attachments/assets/da2429c8-3f09-4c0d-8b38-cdfc3c3e21bc)
**修改后：**
![配置设置-修改后](https://github.com/user-attachments/assets/306635d8-72f6-4063-bd79-f252e42c2ae9)
![常备知识-修改后](https://github.com/user-attachments/assets/e7e1212f-f415-4f2e-82c1-d6abc45dc7e0)